### PR TITLE
Simplify convert and avoid dirty worktree

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,5 +15,4 @@ generate: cleanup
 
 convert:
 	@echo "Converting spec..."
-	cd tools/oapifixer && go build
-	./tools/oapifixer/oapifixer -input ${vbr_spec} -output ${golang_spec}
+	go run ./tools/oapifixer -input ${vbr_spec} -output ${golang_spec}


### PR DESCRIPTION
## Description

When running `make convert`, it builds `oapifixer` in the `tools/oapifixer/` directory. This unnecessarily dirties the worktree.

This change updates the `Makefile` to use a `go run` invocation of the tool so that the executable isn't written to the worktree at all.

### Type of change

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] This change requires a documentation update

### How Has This Been Tested?

`make convert` was run with and without this change to ensure that there was no difference in the generated output.

### Checklist (check all applicable):

* [ ] My code follows the style guidelines of this project
* [x] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in _hard to understand_ areas
* [ ] I have made corresponding changes to the documentation
* [ ] My changes generate no new warnings
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
